### PR TITLE
Update fortiswitch_system_dns.py to contain valid example by changing the dns_cache_ttl value

### DIFF
--- a/plugins/modules/fortiswitch_system_dns.py
+++ b/plugins/modules/fortiswitch_system_dns.py
@@ -109,7 +109,7 @@ EXAMPLES = '''
       system_dns:
           cache_notfound_responses: "disable"
           dns_cache_limit: "4"
-          dns_cache_ttl: "5"
+          dns_cache_ttl: "60"
           domain: "<your_own_value>"
           ip6_primary: "<your_own_value>"
           ip6_secondary: "<your_own_value>"


### PR DESCRIPTION
Change `dns_cache_ttl `from invalid value to valid (minimal) value in the documentation example.

The minimal value for `dns_cache_ttl` is `60`, the current example with `5` results in the following error when used:
` "msg": "Error in repo"`

By changing it to `60`, the example becomes valid config. The [docs](https://docs.fortinet.com/document/fortiswitch/7.6.1/fortiswitchos-cli-reference/500379/config-system#config13), for Fortiswitch CLI does not list the minimum but the CLI of a switch does.

Hardware tested: Fortiswitch 108E PoE, FortiSwitchOS 7.4.5